### PR TITLE
[BUGFIX 158137] Cisco iOS Shell: orchestration_restore doesn't work when running it

### DIFF
--- a/cloudshell/networking/devices/runners/configuration_runner.py
+++ b/cloudshell/networking/devices/runners/configuration_runner.py
@@ -58,7 +58,7 @@ class ConfigurationRunner(ConfigurationOperationsInterface):
         full_path = join(folder_path, destination_filename)
         folder_path = self.get_path(full_path)
         self._save_flow.execute_flow(folder_path=folder_path,
-                                     configuration_type=configuration_type,
+                                     configuration_type=configuration_type.lower(),
                                      vrf_management_name=vrf_management_name)
 
         if return_artifact:
@@ -80,8 +80,8 @@ class ConfigurationRunner(ConfigurationOperationsInterface):
         self._validate_configuration_type(configuration_type)
         path = self.get_path(path)
         self._restore_flow.execute_flow(path=path,
-                                        configuration_type=configuration_type,
-                                        restore_method=restore_method,
+                                        configuration_type=configuration_type.lower(),
+                                        restore_method=restore_method.lower(),
                                         vrf_management_name=vrf_management_name)
 
     def orchestration_save(self, mode="shallow", custom_params=None):


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-networking-devices/5)
<!-- Reviewable:end -->
