### PR TITLE
Added support for new snmp attributes

### DIFF
--- a/cloudshell/devices/driver_helper.py
+++ b/cloudshell/devices/driver_helper.py
@@ -52,7 +52,9 @@ def get_snmp_parameters_from_command_context(resource_config, api, force_decrypt
         return SNMPV3Parameters(ip=resource_config.address,
                                 snmp_user=resource_config.snmp_v3_user or '',
                                 snmp_password=api.DecryptPassword(resource_config.snmp_v3_password).Value or '',
-                                snmp_private_key=resource_config.snmp_v3_private_key or '')
+                                snmp_private_key=resource_config.snmp_v3_private_key or '',
+                                auth_protocol=resource_config.snmp_v3_auth_protocol or 'No Authentication Protocol',
+                                private_key_protocol=resource_config.snmp_v3_priv_protocol or 'No Privacy Protocol')
     else:
         if resource_config.shell_name or force_decrypt:
             write_community = api.DecryptPassword(resource_config.snmp_write_community).Value or ''

--- a/cloudshell/devices/standards/networking/configuration_attributes_structure.py
+++ b/cloudshell/devices/standards/networking/configuration_attributes_structure.py
@@ -133,6 +133,20 @@ class GenericNetworkingResource(object):
         return self.attributes.get("{}SNMP V3 Private Key".format(self.namespace_prefix), None)
 
     @property
+    def snmp_v3_auth_protocol(self):
+        """
+        :rtype: str
+        """
+        return self.attributes.get("{}SNMP V3 Authentication Protocol".format(self.namespace_prefix), None)
+
+    @property
+    def snmp_v3_priv_protocol(self):
+        """
+        :rtype: str
+        """
+        return self.attributes.get("{}SNMP V3 Privacy Protocol".format(self.namespace_prefix), None)
+
+    @property
     def snmp_version(self):
         """
         :rtype: str

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,6 @@
 ipcalc==1.1.3
 jsonpickle==0.9.3
--e git+https://github.com/QualiSystems/cloudshell-shell-core.git@dev#egg=cloudshell-shell-core
--e git+https://github.com/QualiSystems/cloudshell-cli.git@dev#egg=cloudshell-cli
--e git+https://github.com/QualiSystems/cloudshell-snmp.git@dev#egg=cloudshell-snmp
+git+https://github.com/QualiSystems/cloudshell-shell-core.git@dev#egg=cloudshell-shell-core
+git+https://github.com/QualiSystems/cloudshell-cli.git@dev#egg=cloudshell-cli
+git+https://github.com/QualiSystems/cloudshell-snmp.git@dev#egg=cloudshell-snmp
 cloudshell-automation-api>=7.0,<7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ipcalc==1.1.3
 jsonpickle==0.9.3
 cloudshell-shell-core>=3.1,<3.2
-cloudshell-cli>=3.1,<3.2
-cloudshell-snmp>=3.1,<3.2
+cloudshell-cli>=3.2,<3.3
+cloudshell-snmp>=3.2,<3.3
 cloudshell-automation-api>=7.0,<7.1

--- a/tests/devices/test_driver_helper.py
+++ b/tests/devices/test_driver_helper.py
@@ -73,7 +73,9 @@ class TestDriverHelper(unittest.TestCase):
         snmpv3parameters_class.assert_called_once_with(ip=config.address,
                                                        snmp_user=config.snmp_v3_user,
                                                        snmp_password=api.DecryptPassword().Value,
-                                                       snmp_private_key=config.snmp_v3_private_key)
+                                                       snmp_private_key=config.snmp_v3_private_key,
+                                                       auth_protocol=config.snmp_v3_auth_protocol,
+                                                       private_key_protocol=config.snmp_v3_priv_protocol)
 
     @mock.patch("cloudshell.devices.driver_helper.SNMPV2WriteParameters")
     def test_get_snmp_parameters_from_command_context_for_snmp_v2_write_community(self, snmpv2parameters_class):


### PR DESCRIPTION
A preview release of cloudshell-networking-devices-2.1.4:
- Switched to the latest versions of cli and snmp (3.2.0)
- Applied changes to device attributes structure according to a new 5.0.2 standard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/cloudshell-networking-devices/23)
<!-- Reviewable:end -->
